### PR TITLE
CQ-6348: Fix the before timestamp filter for PG

### DIFF
--- a/code/clumio_bulk_dynamodb_list_backups.py
+++ b/code/clumio_bulk_dynamodb_list_backups.py
@@ -135,4 +135,4 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
 
     if not backup_records:
         return {'status': 207, 'records': [], 'target': target, 'msg': 'empty set'}
-    return {'status': 200, 'records': backup_records, 'target': target, 'msg': 'completed'}
+    return {'status': 200, 'records': backup_records[:1], 'target': target, 'msg': 'completed'}

--- a/code/clumio_bulk_ebs_list_backups.py
+++ b/code/clumio_bulk_ebs_list_backups.py
@@ -102,4 +102,4 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
 
     if not backup_records:
         return {'status': 207, 'records': [], 'target': target, 'msg': 'empty set'}
-    return {'status': 200, 'records': backup_records, 'target': target, 'msg': 'completed'}
+    return {'status': 200, 'records': backup_records[:1], 'target': target, 'msg': 'completed'}

--- a/code/clumio_bulk_ec2_list_backups.py
+++ b/code/clumio_bulk_ec2_list_backups.py
@@ -120,4 +120,4 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
 
     if not backup_records:
         return {'status': 207, 'records': [], 'target': target, 'msg': 'empty set'}
-    return {'status': 200, 'records': backup_records, 'target': target, 'msg': 'completed'}
+    return {'status': 200, 'records': backup_records[:1], 'target': target, 'msg': 'completed'}

--- a/code/clumio_bulk_rds_list_backups.py
+++ b/code/clumio_bulk_rds_list_backups.py
@@ -122,4 +122,4 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
 
     if not backup_records:
         return {'status': 207, 'records': [], 'target': target, 'msg': 'empty set'}
-    return {'status': 200, 'records': backup_records, 'target': target, 'msg': 'completed'}
+    return {'status': 200, 'records': backup_records[:1], 'target': target, 'msg': 'completed'}

--- a/code/clumio_bulk_s3_list_backups.py
+++ b/code/clumio_bulk_s3_list_backups.py
@@ -33,11 +33,11 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
     """Handle the lambda function to bulk list S3 backups."""
     bear: str | None = events.get('bear', None)
     base_url: str = events.get('base_url', common.DEFAULT_BASE_URL)
-    start_search_day_offset_input: int = int(events.get('start_search_day_offset', 0))
-    end_search_day_offset_input: int = int(events.get('end_search_day_offset', 0))
     target: dict = events.get('target', {})
+    search_direction: str | None = target.get('search_direction', None)
+    start_search_day_offset_input: int = target.get('start_search_day_offset', 0)
+    end_search_day_offset_input: int = target.get('end_search_day_offset', 10)
     object_filters: dict = events.get('search_object_filters', {})
-    search_direction: str | None = events.get('search_direction', None)
 
     if 'latest_version_only' not in object_filters:
         object_filters['latest_version_only'] = True


### PR DESCRIPTION
Summary:
- Fix the 'before' timestamp filter for ProtectionGroup list backup
- Only restore one backup record based on the timestamp filter

Testing:
- Tested by requesting "before" filter during period where there's actually no backup record existed.
```
events = {
  "debug": 99,
  "search_pg_name": "bulk-restore-test",
  "end_search_day_offset": 10,
  "base_url": "https://systest-8-uw-2-backend.api.qe.clum.io/api/",
  "start_search_day_offset": 0,
  "bear": "",
  "search_bucket_names": [
    "bulk-restore-test-bucket-1"
  ],
  "target": {
    "ResourceType": "ProtectionGroup",
    "search_direction": "before",
    "start_search_day_offset": 0,
    "end_search_day_offset": 10,
    "search_pg_name": "bulk-restore-test",
    "search_bucket_names": [
      "bulk-restore-test-bucket-1"
    ],
    "search_object_filters": {
      "prefix": ""
    },
    "target_account": "222467901403",
    "target_region": "us-east-1",
    "target_bucket": "bulk-restore-test-bucket-1",
    "target_prefix": "restoretest5/"
  }
}
```
- Before:
<img width="701" alt="image" src="https://github.com/user-attachments/assets/bf1b74ae-b318-4713-a618-beb9f5acf449">
- After:
<img width="536" alt="image" src="https://github.com/user-attachments/assets/2e633ecc-fae6-4d47-8b2e-8a8d5a050c47">
