### PR TITLE
CQ-6525: Fix inconsistency in bulk_restore cft

### DIFF
--- a/code/clumio_bulk_restore_deploy_cft.yaml
+++ b/code/clumio_bulk_restore_deploy_cft.yaml
@@ -201,15 +201,15 @@ Resources:
         - |-
           {
             "Comment": "Clumio Bulk Restore",
-            "StartAt": "Lmbda Validate Input",
+            "StartAt": "Lambda Validate Input",
             "States": {
-              "Lmbda Validate Input": {
+              "Lambda Validate Input": {
                 "Type": "Task",
                 "Resource": "arn:aws:states:::lambda:invoke",
                 "OutputPath": "$.Payload",
                 "Parameters": {
                   "Payload.$": "$",
-                  "FunctionName": "{$ValidateInput}:$LATEST"
+                  "FunctionName": "${ValidateInput}:$LATEST"
                 },
                 "Retry": [
                   {


### PR DESCRIPTION
Summary:
- Fix inconsistency in bulk_restore CFT.
- A new version of the ZIP will be released once the PR is merged to ensure the ZIP file matches the CFT.

Testing:
- https://us-west-2.console.aws.amazon.com/states/home?region=us-west-2#/v2/executions/details/arn:aws:states:us-west-2:345454780574:execution:clumio-bulk-restore-state-machine:db1ca051-95e2-4f9c-b860-937acb422545