### PR TITLE
CQ-6778. Add EBS,EC2,RDS to clumio_bulk_invoke_rest_apis

### DIFF
--- a/code/clumio_bulk_dynamodb_list_backups.py
+++ b/code/clumio_bulk_dynamodb_list_backups.py
@@ -81,7 +81,7 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
     search_tag_value: str | None = events.get('search_tag_value', None)
     search_table_id: str | None = events.get('search_table_id', None)
     target: dict = events.get('target', {})
-    search_direction: str = target.get('search_direction', None)
+    search_direction: str | None = target.get('search_direction', None)
     start_search_day_offset_input: int = target.get('start_search_day_offset', 0)
     end_search_day_offset_input: int = target.get('end_search_day_offset', 0)
 

--- a/code/clumio_bulk_invoke_rest_apis.py
+++ b/code/clumio_bulk_invoke_rest_apis.py
@@ -31,6 +31,15 @@ def get_endpoint_mappings(
         'list_aws_dynamodb_tables': client.aws_dynamodb_tables_v1.list_aws_dynamodb_tables(
             filter=filters_str, limit=limit
         ),
+        'list_aws_ebs_volumes': client.aws_ebs_volumes_v1.list_aws_ebs_volumes(
+            filter=filters_str, limit=limit
+        ),
+        'list_aws_ec2_instances': client.aws_ec2_instances_v1.list_aws_ec2_instances(
+            filter=filters_str, limit=limit
+        ),
+        'list_aws_rds_resources': client.aws_rds_resources_v1.list_aws_rds_resources(
+            filter=filters_str, limit=limit
+        ),
         'list_aws_s3_buckets': client.aws_s3_buckets_v1.list_aws_s3_buckets(
             filter=filters_str, limit=limit
         ),
@@ -44,6 +53,15 @@ def get_endpoint_mappings(
             filter=filters_str, limit=limit
         ),
         'list_backup_protection_groups': client.backup_protection_groups_v1.list_backup_protection_groups(
+            filter=filters_str, limit=limit
+        ),
+        'list_backup_aws_ebs_volumes': client.backup_aws_ebs_volumes_v2.list_backup_aws_ebs_volumes(
+            filter=filters_str, limit=limit
+        ),
+        'list_backup_aws_ec2_instances': client.backup_aws_ec2_instances_v1.list_backup_aws_ec2_instances(
+            filter=filters_str, limit=limit
+        ),
+        'list_backup_aws_rds_resources': client.backup_aws_rds_resources_v1.list_backup_aws_rds_resources(
             filter=filters_str, limit=limit
         ),
     }
@@ -60,11 +78,17 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
                 list_aws_environments
                 list_aws_connections
                 list_aws_dynamodb_tables
+                list_aws_ebs_volumes
+                list_aws_ec2_instances
+                list_aws_rds_resources
                 list_aws_s3_buckets
                 list_protection_groups
                 list_protection_group_s3_assets
                 list_backup_aws_dynamodb_tables
                 list_backup_protection_groups
+                list_backup_aws_ebs_volumes
+                list_backup_aws_ec2_instances
+                list_backup_aws_rds_resources
             filters: Filters to apply to the API request.
             limit: The maximum number of results to return. Defaults to 100.
         context: The AWS Lambda context object.


### PR DESCRIPTION
Added support for EBS, EC2, and RDS in the `clumio_bulk_invoke_rest_apis` lambda.