### PR TITLE
CQ-6820. Update clumio SDK version to 0.16.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@
 
 boto3==1.35.59
 
-git+https://github.com/clumio-code/clumio-python-sdk@v0.16.1#egg=clumioapi
+git+https://github.com/clumio-code/clumio-python-sdk@v0.16.2#egg=clumioapi


### PR DESCRIPTION
For the AwsTag change in this PR: https://github.com/clumio-code/clumio-python-sdk/pull/49