### PR TITLE
CQ-6831. Run lambda only for specified resource types

### DIFF
--- a/code/clumio_bulk_dynamodb_restore.py
+++ b/code/clumio_bulk_dynamodb_restore.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from aws_lambda_powertools.utilities.typing import LambdaContext
     from common import EventsTypeDef
 
-logger = logging.getLogger()
+logger = logging.getLogger(__name__)
 
 
 def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, Any]:  # noqa: PLR0911
@@ -105,7 +105,7 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
                 'msg': raw_response.content,
                 'inputs': inputs,
             }
-        logger.info('DynamoDB restore task %s completed successfully.', result.task_id)
+        logger.info('DynamoDB restore task %s started successfully.', result.task_id)
         inputs['task'] = result.task_id
         return {'status': 200, 'msg': 'completed', 'inputs': inputs}
     except exceptions.clumio_exception.ClumioException as e:

--- a/code/clumio_bulk_format_output.py
+++ b/code/clumio_bulk_format_output.py
@@ -36,7 +36,10 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
         asset_backup_lists: list[dict[str, list[dict]]] = region_backup_list['backup_list']
         for asset_backup_list in asset_backup_lists:
             resource_type, backup_list = list(asset_backup_list.items())[0]
+            if resource_type not in common.RESOURCE_TYPES:
+                continue
             for backup_record in backup_list:
+                logger.info('%s backup: %s', resource_type, backup_record)
                 record = format_record_per_resource_type(
                     backup_record, resource_type, source_region, target_specs, is_diff_account
                 )

--- a/code/clumio_bulk_list_deploy_cft.yaml
+++ b/code/clumio_bulk_list_deploy_cft.yaml
@@ -313,28 +313,68 @@ Resources:
                             "Type": "Choice",
                             "Choices": [
                               {
-                                "Variable": "$.resource_type",
-                                "StringEquals": "EBS",
+                                "And":[
+                                  {
+                                    "Variable": "$.resource_type",
+                                    "StringEquals": "EBS"
+                                  },
+                                  {
+                                    "Variable": "$$.Execution.Input.source_asset_types.EBS",
+                                    "IsPresent": true
+                                  }
+                                ],
                                 "Next": "Lambda List EBS Assets"
                               },
                               {
-                                "Variable": "$.resource_type",
-                                "StringEquals": "EC2",
+                                "And":[
+                                  {
+                                    "Variable": "$.resource_type",
+                                    "StringEquals": "EC2"
+                                  },
+                                  {
+                                    "Variable": "$$.Execution.Input.source_asset_types.EC2",
+                                    "IsPresent": true
+                                  }
+                                ],
                                 "Next": "Lambda List EC2 Assets"
                               },
                               {
-                                "Variable": "$.resource_type",
-                                "StringEquals": "RDS",
+                                "And":[
+                                  {
+                                    "Variable": "$.resource_type",
+                                    "StringEquals": "RDS"
+                                  },
+                                  {
+                                    "Variable": "$$.Execution.Input.source_asset_types.RDS",
+                                    "IsPresent": true
+                                  }
+                                ],
                                 "Next": "Lambda List RDS Assets"
                               },
                               {
-                                "Variable": "$.resource_type",
-                                "StringEquals": "DynamoDB",
+                                "And":[
+                                  {
+                                    "Variable": "$.resource_type",
+                                    "StringEquals": "DynamoDB"
+                                  },
+                                  {
+                                    "Variable": "$$.Execution.Input.source_asset_types.DynamoDB",
+                                    "IsPresent": true
+                                  }
+                                ],
                                 "Next": "Lambda List DynamoDB Assets"
                               },
                               {
-                                "Variable": "$.resource_type",
-                                "StringEquals": "ProtectionGroup",
+                                "And":[
+                                  {
+                                    "Variable": "$.resource_type",
+                                    "StringEquals": "ProtectionGroup"
+                                  },
+                                  {
+                                    "Variable": "$$.Execution.Input.source_asset_types.ProtectionGroup",
+                                    "IsPresent": true
+                                  }
+                                ],
                                 "Next": "Lambda List PG Assets"
                               }
                             ],

--- a/code/clumio_bulk_s3_list_backups.py
+++ b/code/clumio_bulk_s3_list_backups.py
@@ -71,7 +71,7 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
 
     # Get bucket names filter.
     s3_bucket_names: list = []
-    if source_asset_types and 'ProtectionGroup' in source_asset_types:
+    if source_asset_types and 'protection_groups' in source_asset_types['ProtectionGroup']:
         for protection_group in source_asset_types['ProtectionGroup']['protection_groups']:
             if protection_group['name'] == search_name:
                 s3_bucket_names = protection_group['bucket_names']

--- a/code/common.py
+++ b/code/common.py
@@ -36,6 +36,7 @@ MAX_RETRY: Final = 5
 START_TIMESTAMP_STR: Final = 'start_timestamp'
 STATUS_OK: Final = 200
 FOLLOW_DEFAULT_INPUT: Final = '[This field will follow default input]'
+RESOURCE_TYPES: Final = ['EBS', 'EC2', 'RDS', 'DynamoDB', 'ProtectionGroup']
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
1. Only call lambdas for resources that are specified in the `source_asset_types`. 
2.  When `clumio_bulk_dynamodb_list_backups` is called from the restore state machine, it needs to get the `search_table_id` from the target. Without this, it wasn't filtering by table_id.