### PR TITLE
CQ-6851. Fix search_object_filters formatted output

### DIFF
--- a/code/clumio_bulk_format_output.py
+++ b/code/clumio_bulk_format_output.py
@@ -132,6 +132,7 @@ def format_record_per_resource_type(
             {
                 'search_pg_name': backup['pg_name'],
                 'search_bucket_names': backup['pg_bucket_names'],
+                'search_object_filters': backup['object_filters'],
             }
         )
     else:


### PR DESCRIPTION
It was only posting the user-specified object filters but the input is modified in the `clumio_bulk_s3_list_latest_backup` lambda if the `latest_version_only` filter is not specified.