### PR TITLE
CQ-6858. Add append_tags restore option for DynamoDB

### DIFF
--- a/code/clumio_bulk_list_deploy_cft.yaml
+++ b/code/clumio_bulk_list_deploy_cft.yaml
@@ -472,6 +472,7 @@ Resources:
                               "source_account.$": "$$.Execution.Input.source_account",
                               "source_region.$": "$.region",
                               "search_table_id.$": "$$.Map.Item.Value",
+                              "target_specs.$": "$$.Execution.Input.target_specs",
                               "target": {
                                 "search_direction": "before"
                               }

--- a/examples/clumio_bulk_list_inputs_example.json
+++ b/examples/clumio_bulk_list_inputs_example.json
@@ -86,7 +86,8 @@
       },
       "DynamoDB":{
          "target_region":"OPTIONAL",
-         "change_set_name":"REQUIRED if the rest is empty,"
+         "change_set_name":"REQUIRED: suffix appended to the restored table name",
+         "append_tags": {"key1":"val1", "key2":"val2"}
       },
       "RDS":{
          "target_region":"OPTIONAL",


### PR DESCRIPTION
Added `append_tags` option to append additional tags to the restored DDB tables.