### PR TITLE
CQ-6909. Add tags to EC2 attached volumes

### DIFF
--- a/code/clumio_bulk_dynamodb_list_backups.py
+++ b/code/clumio_bulk_dynamodb_list_backups.py
@@ -150,13 +150,4 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
         logger.info('No DynamoDB backup records found.')
         return {'status': 207, 'records': [], 'target': target, 'msg': 'empty set'}
 
-    # Modify tags if append_tags was provided in the target_specs input.
-    # This only applies to the list state machine path.
-    if append_tags:
-        for backup in backup_records:
-            tags = backup['backup_record']['source_ddn_tags']
-            backup['backup_record']['source_ddn_tags'] = common.append_tags_to_source_tags(
-                tags, append_tags
-            )
-
     return {'status': 200, 'records': backup_records[:1], 'target': target, 'msg': 'completed'}

--- a/code/clumio_bulk_ebs_list_backups.py
+++ b/code/clumio_bulk_ebs_list_backups.py
@@ -118,13 +118,4 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
         logger.info('No EBS backup records found.')
         return {'status': 207, 'records': [], 'target': target, 'msg': 'empty set'}
 
-    # Modify tags if append_tags was provided in the target_specs input.
-    # This only applies to the list state machine path.
-    if append_tags:
-        for backup in backup_records:
-            tags = backup['backup_record']['source_volume_tags']
-            backup['backup_record']['source_volume_tags'] = common.append_tags_to_source_tags(
-                tags, append_tags
-            )
-
     return {'status': 200, 'records': backup_records[:1], 'target': target, 'msg': 'completed'}

--- a/code/clumio_bulk_ec2_list_backups.py
+++ b/code/clumio_bulk_ec2_list_backups.py
@@ -141,13 +141,4 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
         logger.info('No EC2 backup records found.')
         return {'status': 207, 'records': [], 'target': target, 'msg': 'empty set'}
 
-    # Modify tags if append_tags was provided in the target_specs input.
-    # This only applies to the list state machine path.
-    if append_tags:
-        for backup in backup_records:
-            tags = backup['backup_record']['source_instance_tags']
-            backup['backup_record']['source_instance_tags'] = common.append_tags_to_source_tags(
-                tags, append_tags
-            )
-
     return {'status': 200, 'records': backup_records[:1], 'target': target, 'msg': 'completed'}

--- a/code/clumio_bulk_ec2_restore.py
+++ b/code/clumio_bulk_ec2_restore.py
@@ -45,6 +45,7 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
     target_vpc_native_id = target.get('target_vpc_native_id', None)
     target_kms_key_native_id = target.get('target_kms_key_native_id', None)
     target_instance_tags: list[dict[str, Any]] | None = target.get('target_instance_tags', None)
+    target_volume_append_tags = target.get('target_volume_append_tags', [])
     should_power_on = target.get('should_power_on', False)
     target_ami_native_id = target.get('target_ami_native_id', None)
 
@@ -83,7 +84,7 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
             kms_key_native_id=ebs_storage['kms_key_native_id'] or target_kms_key_native_id,
             name=ebs_storage['name'],
             volume_native_id=ebs_storage['volume_native_id'],
-            tags=common.tags_from_dict(ebs_storage['tags']),
+            tags=common.tags_from_dict(ebs_storage['tags'] + target_volume_append_tags),
         )
         for ebs_storage in backup_record.get('source_ebs_storage_list', [])
     ]

--- a/code/clumio_bulk_format_output.py
+++ b/code/clumio_bulk_format_output.py
@@ -93,10 +93,10 @@ def format_record_per_resource_type(
     backup_record = backup.get('backup_record', {})
     region = resource_target_specs.get('target_region', '') or source_region
     if resource_type == 'EBS':
-        updated_tags = backup_record.get('source_volume_tags', None)
+        updated_tags = backup_record.get('source_volume_tags', [])
         append_tags = resource_target_specs.get('append_tags', {})
         if append_tags:
-            updated_tags = append_tags_to_source_tags(updated_tags, append_tags)
+            updated_tags = common.append_tags_to_source_tags(updated_tags, append_tags)
         output_record.update(
             {
                 'search_volume_id': backup['volume_id'],
@@ -106,15 +106,17 @@ def format_record_per_resource_type(
         )
         output_record.update(get_target_specs_ebs(resource_target_specs, backup_record))
     elif resource_type == 'EC2':
-        updated_tags = backup_record.get('source_instance_tags', None)
+        updated_tags = backup_record.get('source_instance_tags', [])
         append_tags = resource_target_specs.get('append_tags', {})
+        append_tags_ebs = common.format_append_tags(append_tags)
         if append_tags:
-            updated_tags = append_tags_to_source_tags(updated_tags, append_tags)
+            updated_tags = common.append_tags_to_source_tags(updated_tags, append_tags)
         output_record.update(
             {
                 'search_instance_id': backup['instance_id'],
                 'target_region': region,
                 'target_instance_tags': updated_tags,
+                'target_volume_append_tags': append_tags_ebs,
             }
         )
         output_record.update(
@@ -123,10 +125,10 @@ def format_record_per_resource_type(
     elif resource_type == 'DynamoDB':
         changed_name = resource_target_specs.get('change_set_name', None)
         changed_name = changed_name or common.generate_random_string(4)
-        updated_tags = backup_record.get('source_ddn_tags', None)
+        updated_tags = backup_record.get('source_ddn_tags', [])
         append_tags = resource_target_specs.get('append_tags', {})
         if append_tags:
-            updated_tags = append_tags_to_source_tags(updated_tags, append_tags)
+            updated_tags = common.append_tags_to_source_tags(updated_tags, append_tags)
         output_record.update(
             {
                 'search_table_id': backup_record['source_table_id'],
@@ -136,10 +138,10 @@ def format_record_per_resource_type(
             }
         )
     elif resource_type == 'RDS':
-        updated_tags = backup_record.get('source_resource_tags', None)
+        updated_tags = backup_record.get('source_resource_tags', [])
         append_tags = resource_target_specs.get('append_tags', {})
         if append_tags:
-            updated_tags = append_tags_to_source_tags(updated_tags, append_tags)
+            updated_tags = common.append_tags_to_source_tags(updated_tags, append_tags)
         output_record.update(
             {
                 'search_resource_id': backup['resource_id'],
@@ -162,31 +164,6 @@ def format_record_per_resource_type(
     else:
         return {}
     return output_record
-
-
-def append_tags_to_source_tags(
-    source_tags: list[dict[str, Any]] | None, append_tags: dict[str, Any]
-) -> list[dict[str, Any]]:
-    """Update tags to be added to the restored asset.
-
-    Args:
-        source_tags: Asset tags in backup record.
-            In format [{'key': 'key1', 'value': 'value1'}] or None.
-        append_tags: Additional tags to be added to the restored asset.
-            In format {'key2': 'value2', 'key3': 'value3'}.
-    Returns:
-        Updated tags.
-    """
-    updated_tags = []
-    if source_tags:
-        updated_tags = source_tags.copy()
-    for tag_key, tag_value in append_tags.items():
-        tag = {'key': tag_key, 'value': tag_value}
-        if tag not in updated_tags:
-            logger.info('Append tag: %s', tag)
-            updated_tags.append(tag)
-    logger.info('Tags updated: %s', updated_tags)
-    return updated_tags
 
 
 def get_target_specs_ebs(specs: dict[str, Any], record: dict[str, Any]) -> dict:

--- a/code/clumio_bulk_rds_list_backups.py
+++ b/code/clumio_bulk_rds_list_backups.py
@@ -135,13 +135,4 @@ def lambda_handler(events: EventsTypeDef, context: LambdaContext) -> dict[str, A
         logger.info('No RDS backup records found.')
         return {'status': 207, 'records': [], 'target': target, 'msg': 'empty set'}
 
-    # Modify tags if append_tags was provided in the target_specs input.
-    # This only applies to the list state machine path.
-    if append_tags:
-        for backup in backup_records:
-            tags = backup['backup_record']['source_resource_tags']
-            backup['backup_record']['source_resource_tags'] = common.append_tags_to_source_tags(
-                tags, append_tags
-            )
-
     return {'status': 200, 'records': backup_records[:1], 'target': target, 'msg': 'completed'}

--- a/code/common.py
+++ b/code/common.py
@@ -241,6 +241,14 @@ def get_append_tags(target_specs: dict, resource_type: str) -> dict:
     return append_tags
 
 
+def format_append_tags(append_tags: dict) -> list[dict]:
+    """Format user-provided append_tags to AWS format."""
+    tags = []
+    for tag_key, tag_value in append_tags.items():
+        tags.append({'key': tag_key, 'value': tag_value})
+    return tags
+
+
 def append_tags_to_source_tags(tags: list[dict], append_tags: dict) -> list[dict]:
     """Append the append_tags from target_specs to the asset source tags for restore."""
     if tags is None:


### PR DESCRIPTION
1. Updated EC2 restore to append the `append_tags` to each of the attached volumes.
2. Removed unnecessary code.